### PR TITLE
cwToolbarItem.cls: remove If condition on W_MouseMove

### DIFF
--- a/cwToolBarItem.cls
+++ b/cwToolBarItem.cls
@@ -41,9 +41,8 @@ Private Sub W_MouseDown(Button As Integer, Shift As Integer, ByVal x As Single, 
   If Button = 1 Then BDown = True: W.Refresh
 End Sub
 Private Sub W_MouseMove(Button As Integer, Shift As Integer, ByVal x As Single, ByVal y As Single)
-Dim NewOutsideValue As Boolean
   
-  NewOutsideValue = (x < 0 Or x > dx Or y < 0 Or y > dy)
+  OutSide = (x < 0 Or x > dx Or y < 0 Or y > dy)
   
   MOverArrow = IIf(ArrowType > 0 And Not OutSide And x > dx - 16, True, False)
   


### PR DESCRIPTION
In W_MouseMove, the lines:

  If BDown And (NewOutsideValue <> OutSide) Then
    OutSide = NewOutsideValue
  Else
    OutSide = NewOutsideValue
  End If

are not needed, because in either case the variable OutSide is set equal to NewOutsideValue.
