### PR TITLE
Unhandled error (91) in PopUp_CheckForAdditionalCloseConditions.

### DIFF
--- a/cwMenu.cls
+++ b/cwMenu.cls
@@ -299,7 +299,9 @@ Private Sub PopUp_CheckForAdditionalCloseConditions()
   If mInitiatorWidget.object Is Nothing Then Exit Sub
   If TypeOf mInitiatorWidget.object Is cwMenu Then Exit Sub
   If mInitiatorWidget.Root Is Nothing Then Exit Sub
-  If Not mActiveRootWidget Is mInitiatorWidget.Root.ActiveWidget Then DestroyPopup
+  If Not mActiveRootWidget Is mInitiatorWidget.Root.ActiveWidget Then
+    DestroyPopup: Exit Sub
+  end if
   If mInitiatorWidget.Root.WidgetForm Is Nothing Then Exit Sub
   If mInitiatorWidget.Root.WidgetForm.Parent Is Nothing Then
     If mInitiatorWidget.Root.WidgetForm.WindowState = vbMinimized Then DestroyPopup


### PR DESCRIPTION
After the call to DestroyPopup on line 302, all menus are destroyed, so mInitiatorWidget is set to nothing: now the line 303 raise an error (91) at runtime.
Step to reproduce:
1. launch the MenuBarDemo.vbp;
2. press Alt + E (menu Edit is shown);
3. press Alt + Tab and set the focus  to another window;
4. press Alt + Tab until you return to the MenuBarDemo;
5. press Alt + E: the error is raised.

I think that after the call to DestroyPopup it's safe to exit the sub.
