### PR TITLE
Added Option-like MenuItem functionality

### DIFF
--- a/cwMenu.cls
+++ b/cwMenu.cls
@@ -25,6 +25,13 @@ Event Click(ByVal CurMenuItemPath As String)
 Event MenuBarEntryShift(ByVal ShiftLeft As Boolean)
 Event MenuDestroyed(ByVal DestroyedByKeyPress As Boolean)
 
+'To have a option-like MenuItem, you must set the IsCheckable property to True and set the IconKey property
+'to this value:
+Private Const OptionMenuItemIconKey = "OptMenuItem"
+'No real IconResource is needed at all in the global Cairo.ImageList - the IconImageKey is just used as
+'the "magic Indicator" for the OptionBox-Rendering-Workaround.
+'This is done because the cMenuItem class have not a IsOption property in RC5's vbRichClient.dll
+
 Private WithEvents PopUp As cfPopUp 'this PopupForm-HelperClass is hosted here in the vbWidgets.dll-Project
 Attribute PopUp.VB_VarHelpID = -1
 Private WithEvents mInitiatorWidget As cWidgetBase
@@ -192,6 +199,9 @@ Dim i As Long, dx As Double, dy As Double, Caption As String
         MenuItem.Widget.BackColor = W.BackColor
         MenuItem.Caption = Caption
         MenuItem.IsCheckable = DSItem.IsCheckable
+        MenuItem.IsOption = DSItem.IconKey = OptionMenuItemIconKey  'Here is the workaround to have
+                                                                    'option-like cwMenuItems from cMenuItems
+                                                                    'with "magic" iconkey indicator
         If DSItem.IsCheckable Then MenuItem.Checked = DSItem.Checked
         If Caption = "-" Then MenuItem.Widget.Enabled = False
         If DSItem.SubItemCount Then Set MenuItem.SubMenuDS = DSItem
@@ -428,7 +438,11 @@ Public Sub KeyDown(KeyCode As Integer, Shift As Integer)
       
       If Not MItem Is Nothing Then
         If MItem.Widget.Enabled Then
-          If Not RootMenu Is Nothing Then mDestroyedByKeyPress = True: RootMenu.RaiseClick MenuItemKeyPath
+          If Not RootMenu Is Nothing Then
+            mDestroyedByKeyPress = True
+            If MItem.IsOption Then UnCheckAllMenuOptions MItem
+            RootMenu.RaiseClick MenuItemKeyPath
+          End If
         End If
       End If
       If Not RootMenu Is Nothing Then mDestroyedByKeyPress = True: RootMenu.DestroyPopup
@@ -460,7 +474,10 @@ Public Sub W_MouseUp(Button As Integer, Shift As Integer, ByVal x As Single, ByV
       If Not mActiveMenuItem.SubMenuDS Is Nothing Then
         ShowSubMenu mActiveMenuItem
       ElseIf mActiveMenuItem.Widget.Enabled Then
-        If Not RootMenu Is Nothing Then RootMenu.RaiseClick MenuItemKeyPath
+        If Not RootMenu Is Nothing Then
+          If mActiveMenuItem.IsOption Then UnCheckAllMenuOptions mActiveMenuItem    'First we clear all the options
+          RootMenu.RaiseClick MenuItemKeyPath                                       'And in here we set the current one
+        End If
       End If
     End If
   End If
@@ -485,4 +502,19 @@ Private Sub W_Paint(CC As cCairoContext, ByVal xAbs As Single, ByVal yAbs As Sin
   W.Alpha = 0.7
   Cairo.Theme.DrawTo CC, W, thmTypeBorder, 0, 0, 0, dx_Aligned, dy_Aligned
   W.Alpha = 1
+End Sub
+
+Private Sub UnCheckAllMenuOptions(MItem As cwMenuItem)
+'Unchecks all the menu options items that are in the same level of hierarchy of MItem
+Dim V, MItemX As cwMenuItem
+  If MItem.Widget.Parent Is Nothing Then Exit Sub
+  If MItem.Widget.Parent.ChildCount = 0 Then Exit Sub
+  For Each V In MItem.Widget.Parent.Widgets
+    If TypeOf V Is cwMenuItem Then
+      Set MItemX = V
+      If MItemX.IsOption Then
+        mDataSource.SubItemByKey(MItemX.Widget.Key).Checked = False
+      End If
+    End If
+  Next
 End Sub

--- a/cwMenuItem.cls
+++ b/cwMenuItem.cls
@@ -16,7 +16,8 @@ Option Explicit
 Event ShowSubMenu(Sender As cwMenuItem)
 
 Private dx As Single, dy As Single, Alpha As Single
-Private mCaption As String, mSubMenuDS As cMenuItem, mIsCheckable, mChecked As Boolean
+Private mCaption As String, mSubMenuDS As cMenuItem
+Private mIsCheckable As Boolean, mChecked As Boolean, mIsOption As Boolean
 Private WithEvents tmrSubMenuHover As cTimer
 Attribute tmrSubMenuHover.VB_VarHelpID = -1
 
@@ -67,6 +68,14 @@ Public Property Get IsCheckable() As Boolean
 End Property
 Friend Property Let IsCheckable(ByVal NewValue As Boolean)
   mIsCheckable = NewValue
+  If Not NewValue Then mIsOption = False    'IsOption works only if IsCheckable
+End Property
+ 
+Public Property Get IsOption() As Boolean
+  IsOption = mIsOption
+End Property
+Friend Property Let IsOption(ByVal NewValue As Boolean)
+  mIsOption = NewValue
 End Property
  
 Private Sub W_LostFocus()
@@ -128,7 +137,13 @@ Const IcoOffsX& = 30, IcoSize& = 16, ArrowSize& = 9
     If mIsCheckable Then
       W.Alpha = 0.3
       Cairo.Theme.DrawTo CC, W, thmTypeListSelection, 0, 2, 0, dy + 2, dy, 3
-      If mChecked Then DrawCheckMark CC, IcoSize + 3
+      If mChecked Then
+        If mIsOption Then
+          DrawOptionMark CC, IcoSize + 3
+        Else
+          DrawCheckMark CC, IcoSize + 3
+        End If
+      End If
     End If
     
     W.Alpha = Alpha
@@ -160,3 +175,29 @@ Dim x As Double, y As Double
       CC.SetSourceColor W.FocusColor, 0.35
     CC.Stroke
 End Sub
+
+Private Sub DrawOptionMark(CC As cCairoContext, ByVal OptionSize As Long)
+Dim x As Double, y As Double
+    y = (W.Height - OptionSize) / 2 + 2
+    x = y + 3.3
+    CC.SetLineCap Cairo_LINE_CAP_ROUND
+      CC.SetSourceColor W.FocusColor, 0.85, 0.27
+      OptionSize = OptionSize - 8
+      x = x + 2 + OptionSize / 2
+      y = y + 2 + OptionSize / 2
+     
+    Dim Pat As cCairoPattern
+    CC.ARC x, y, OptionSize / 2
+  
+    Set Pat = Cairo.CreateRadialPattern(x, y, OptionSize / 2, x + OptionSize / 6, y - OptionSize / 4, 0)
+      Pat.AddColorStop 1, W.FocusColor, 0#
+      Pat.AddColorStop 0, W.FocusColor, 0.85, 0.27
+    CC.Fill True, Pat
+      
+    CC.SetLineWidth 1
+      CC.SetSourceColor W.FocusColor, 0.35
+    CC.Stroke
+End Sub
+
+
+


### PR DESCRIPTION
Set the Check property to True and the IconKey to the special value "OptMenuItem" to use it (As discused in #12)

I've found out that the checked MenuItems are displayed in a particular way, not passing by the cTheme class (DrawCheckMark Sub), so I have done the Option Drawing in the same way (trying to achieve a similar look).

You could test the Menu with your "MenuBarAndToolBar" example, by adding the following lines in the AddExtrMenuEntries Sub, in modMenuResources:

``` VB
  Set SubMenuPar = MI.AddSubItem("Item6", "&Another SubMenu", "Document-Open")

    'three entries into the SubMenu (as children of 'Item6' of the above Code-Block) that are Option-like:
    SubMenuPar.AddSubItem "SubItem6-1", "Option &1", "OptMenuItem", , True
    SubMenuPar.AddSubItem "SubItem6-2", "Option &2", "OptMenuItem", , False
    SubMenuPar.AddSubItem "SubItem6-3", "Option &3", "OptMenuItem", , False
    'and just a few more:
    SubMenuPar.AddSubItem "SubItem6-4", "-", , , False
    SubMenuPar.AddSubItem "SubItem6-5", "Check &4", , , True

  Set SubMenuPar = MI.AddSubItem("Item7", "&Yet another SubMenu", "Edit-Copy")

    'three entries into the SubMenu (as children of 'Item7' of the above Code-Block) that are Option-like:
    SubMenuPar.AddSubItem "SubItem6-1", "Another Option &1", "OptMenuItem", , True
    SubMenuPar.AddSubItem "SubItem6-2", "Another Option &2", "OptMenuItem", , False
    SubMenuPar.AddSubItem "SubItem6-3", "Another Option &3", "OptMenuItem", , False
    'and just a few more:
    SubMenuPar.AddSubItem "SubItem6-4", "-", , , False
    SubMenuPar.AddSubItem "SubItem6-5", "Another Check &4", , , True
```

Greetings, Kbre.
